### PR TITLE
Fix resource load order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use bevy::{input::system::exit_on_esc_system, prelude::*};
 
-mod notes;
+mod gameplay;
 mod consts;
 mod types;
 mod ui;
 
-use notes::NotesPlugin;
+use gameplay::NotesPlugin;
 use ui::UIPlugin;
 
 fn main() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,38 +1,4 @@
 use bevy::prelude::*;
-use crate::consts::*;
-
-// Texture for UI (lanes, drum, background etc.)
-struct UIMaterialResource {
-    lane_texture: Handle<ColorMaterial>,
-}
-impl FromWorld for UIMaterialResource {
-    fn from_world(world: &mut World) -> Self {
-        let world = world.cell();
-
-        let mut materials = world.get_resource_mut::<Assets<ColorMaterial>>().unwrap();
-        let asset_server = world.get_resource::<AssetServer>().unwrap();
-
-        let lane_handle = asset_server.load("images/note-lane.png");
-        UIMaterialResource {
-            lane_texture: materials.add(lane_handle.into()),
-        }
-    }
-}
-
-// Spawn Lane
-struct Lanes;
-
-fn setup_lane(mut commands: Commands, materials: Res<UIMaterialResource>) {
-    let transform = Transform::from_translation(Vec3::new(0.,LANE_Y_AXIS, 1.));
-    commands
-        .spawn_bundle(SpriteBundle {
-            material: materials.lane_texture.clone(),
-            sprite: Sprite::new(Vec2::new(1366., 200.)),
-            transform,
-            ..Default::default()
-        })
-        .insert(Lanes);
-}
 
 // Setup time UI
 fn setup_ui(
@@ -129,8 +95,6 @@ pub struct UIPlugin;
 impl Plugin for UIPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app
-            .init_resource::<UIMaterialResource>()
-            .add_startup_system(setup_lane.system())
             .add_startup_system(setup_ui.system())
             .add_system(update_time_text.system());
     }


### PR DESCRIPTION
- Renaming `UIMaterialResource` to `LaneMaterialResource` (Will be use this later on lane animation or something)
- Rename `notes.rs` to `gameplay.rs` and move `setup_lane` to `gameplay.rs`
- Order system build order to close #1 